### PR TITLE
Short files

### DIFF
--- a/code/python/config.yaml
+++ b/code/python/config.yaml
@@ -24,3 +24,26 @@ Public:
 - cmeNT
 - cotNT
 - urd
+Short:
+- alh
+- kij
+- kld
+- nld
+- sancol
+- sankan
+- ygr
+- djj
+- rmb
+- wlg
+- kky
+- adt
+- kux
+- yij
+- gia
+- gupk
+- gue
+- byr-w
+- kjn
+- thd
+- omw-v
+- nay

--- a/code/python/config.yaml
+++ b/code/python/config.yaml
@@ -1,13 +1,9 @@
 No Download:
-- due
 - engamp
 - engnasb
 - khm-h
 - khm
 - kij
-- nld
-- sancol
-- sankan
 - spaLBLA
 - spanblh
 - ygr

--- a/code/python/ebible.py
+++ b/code/python/ebible.py
@@ -546,6 +546,10 @@ def main() -> None:
     dont_download_filenames = [
         project + "_usfm.zip" for project in config["No Download"]
     ]
+
+    # These files have fewer than 400 lines of text in January 2023
+    dont_download_filenames.extend([ project + "_usfm.zip" for project in config["Short"]])
+
     dont_download_files = [
         downloads_folder / dont_download_filename
         for dont_download_filename in dont_download_filenames


### PR DESCRIPTION
Add code and a command line argument so that we can try to download the files that don't usually download.
I reported the non-downloading files to eBible.org and four of them do now download. I've removed those four from the config.yaml file.