### PR TITLE
Fix extract filename bugs

### DIFF
--- a/code/python/rename_usfm.py
+++ b/code/python/rename_usfm.py
@@ -3,9 +3,9 @@ import regex
 from pathlib import Path
 
 
-def rename_usfm(projects_dir: Path) -> None:
+def rename_usfm(project_dir: Path) -> None:
     """
-    Renames the .usfm files to a standardized format by removing the leading 3 characters in some cases.
+    Renames the .usfm files within a project to a standardized format by removing the leading 3 characters in some cases.
 
     The .usfm files in the zips have numerical prefixes, e.g.
       01-INTcmn2006.usfm
@@ -19,12 +19,18 @@ def rename_usfm(projects_dir: Path) -> None:
     So it is simpler to remove the leading 3 characters, then do:
         // Settings.xml
         <Naming BookNameForm="MAT"
-    See also settings_file.py method `write_settings_file`.
+
+    Currently we only remove the prefixes.
+    We could potentially also change the suffix of the filenames to align with the renamed project format,
+    Project: eng-web-c    -> web_c
+    File:    MATeng-web-c -> MATweb_c
+    That might be less confusing than the mix we have now.
+    See also settings_file.py `write_settings_file` and ebible.py `create_project_name`.
     """
-    usfm_paths = list(projects_dir.glob("*/*.usfm"))
+    usfm_paths = list(project_dir.glob("*.usfm"))
     for old_usfm_path in usfm_paths:
         name = old_usfm_path.name
-        if regex.match("\d\d-", name):
+        if regex.match("^\d\d-", name):
             new_name: str = old_usfm_path.name[3:]
             new_usfm_path: Path = old_usfm_path.parent / new_name
             os.rename(old_usfm_path, new_usfm_path)

--- a/code/python/settings_file.py
+++ b/code/python/settings_file.py
@@ -324,7 +324,7 @@ def get_versification(
     return versifications[0]
 
 
-def write_settings_file(project_folder: Path) -> Path:
+def write_settings_file(project_folder: Path, language_code: str, translation_id: str) -> Path:
     """
     Write a Settings.xml file to the project folder passed if one doesn't exist already.
 
@@ -335,23 +335,27 @@ def write_settings_file(project_folder: Path) -> Path:
 
     When a settings file is created, the path to it is returned.
     Otherwise None is returned.
+
+    Note that the "Naming->PostPart" section will reflect the original naming scheme of the files in the original zip.
+    For example if the original zip was eng-web-c.zip, then the files inside will have names like MATeng-web-c.usfm,
+    even though for that language, we would have changed the project name to web_c
+    See also ebible.py `create_project_name` method, and rename_usfm.py and
+    https://github.com/BibleNLP/ebible/issues/50#issuecomment-2659064715
     """
 
     # Now add a Settings.xml file to a project folder.
     if project_folder.is_dir():
-        language_code = str(project_folder.name)[:3]
         settings_file = project_folder / "Settings.xml"
 
         if settings_file.is_file():
             return None
         else:
-            # print(f"Adding Settings.xml to {project_folder}")
             versification = get_versification(project_folder, get_vrs_diffs())
             vrs_num = vrs_to_num[versification]
             setting_file_text = f"""<ScriptureText>
                                 <Versification>{vrs_num}</Versification>
                                 <LanguageIsoCode>{language_code}:::</LanguageIsoCode>
-                                <Naming BookNameForm="MAT" PostPart="{project_folder.name}.usfm" PrePart="" />
+                                <Naming BookNameForm="MAT" PostPart="{translation_id}.usfm" PrePart="" />
                                 </ScriptureText>"""
 
             with open(settings_file, "w") as settings:


### PR DESCRIPTION
Fixes the issue where extract files are being generated with a duplicated language code on the front and didn't have hyphens replaced with underscores in the translation description.

Examples:

```
Translation id | Previous project name | Previous extract filename | Correct?  | Current project name | Current extract filename
---------------------------------------------------------------------------------------------------------------------------------
aoj            | aoj                   | aoj-aoj.txt               | Correct   | aoj                  | aoj-aoj.txt
abt-maprik     | abt-maprik            | abt-abt-maprik.txt        | Incorrect | maprik               | abt-maprik.txt
eng-web-c      | eng-web-c             | eng-eng-web-c.txt         | Incorrect | web_c                | eng-web_c.txt
```

The reason for the duplicated language codes is that the `bulk_extract_corpora` script creates the extract filename by prepending the language code onto the paratext project name. So if the project name already has a language code, then you get it twice.

My fix is to pre-emptively remove the language code from paratext project name in anticipation of it being added later by `bulk_extract_corpora`.

To make that change required doing a fair bit of restructuring of the code, hence this PR is pretty big. I've put some annotations on the PR to make the changes easier to understand.

---

Once this PR is approved, the two main issues should be fixed:

- blank files
- incorrect filenames

At that point I'll regenerate the extract files and raise a follow up PR and confirm all regression tests are passing.