### PR TITLE
Misc improvements to ebible.py script revolving around the licence details

### DIFF
--- a/code/python/ebible.py
+++ b/code/python/ebible.py
@@ -263,8 +263,6 @@ def get_licence_details(logfile, folder, project_path_to_translation_id: Dict[Pa
         "Translation by",
     ]
 
-    # Get copyright info from eBible projects
-
     data = list()
 
     log_and_print(
@@ -292,7 +290,6 @@ def get_licence_details(logfile, folder, project_path_to_translation_id: Dict[Pa
 
         cclink = soup.find(href=regex.compile("creativecommons"))
         if cclink:
-            # TODO - find an example that uses this
             ref = cclink.get("href")
             if ref:
                 entry["CC Licence Link"] = ref
@@ -363,19 +360,7 @@ def get_licence_details(logfile, folder, project_path_to_translation_id: Dict[Pa
 
 def write_licence_file(licence_file, logfile, df):
 
-    # df.columns = [
-    #     "ID",
-    #     "File",
-    #     "Language",
-    #     "Dialect",
-    #     "Vernacular Title",
-    #     "Licence Type",
-    #     "Licence Version",
-    #     "CC Licence Link",
-    #     "Copyright Holder",
-    #     "Copyright Years",
-    #     "Translation by",
-    # ]
+    # For a description of the schema, see `column_headers` list in method `get_licence_details`
 
     df.to_csv(licence_file, sep="\t", index=False)
 
@@ -400,7 +385,6 @@ def check_folders_exist(folders: list, base: Path, logfile):
 
     # Don't log_and_print until we've checked that the log folder exists.
     print(f"The base folder is : {base}")
-    # base = r"F:/GitHub/davidbaines/eBible"
 
     if missing_folders:
         print(

--- a/code/python/ebible.py
+++ b/code/python/ebible.py
@@ -250,8 +250,8 @@ def get_licence_details(logfile, folder, project_path_to_translation_id: Dict[Pa
     """
 
     column_headers = [
-        "ID",
-        "File",
+        "ID", # Original translation id corresponding to the project
+        "File", # Path to the paratext project
         "Language",
         "Dialect",
         "Vernacular Title",

--- a/code/python/ebible.py
+++ b/code/python/ebible.py
@@ -403,33 +403,6 @@ def check_folders_exist(folders: list, base: Path, logfile):
         log_and_print(logfile, f"All the required folders exist in {base}")
 
 
-def move_projects(
-    projects_to_move: List, parent_source_folder: Path, parent_dest_folder: Path
-) -> List[Path]:
-
-    moved = []
-    for project_to_move in projects_to_move:
-        source_folder = parent_source_folder / project_to_move
-        dest_folder = parent_dest_folder / project_to_move
-        # print(
-        #     f"{source_folder} exists: {source_folder.exists()}   Dest: {dest_folder} exists: {dest_folder.exists()}  Move: {source_folder.exists() and not dest_folder.exists()}"
-        # )
-
-        if source_folder.exists() and not dest_folder.exists():
-            shutil.move(str(source_folder), str(dest_folder))
-            assert not source_folder.exists()
-            assert dest_folder.exist()
-            moved.append(project_to_move)
-
-    return moved
-
-
-def is_dir(folder):
-    if folder.is_dir():
-        return folder
-    return False
-
-
 def main() -> None:
 
     parser: argparse.ArgumentParser = argparse.ArgumentParser(

--- a/code/python/ebible.py
+++ b/code/python/ebible.py
@@ -342,8 +342,11 @@ def get_licence_details(logfile, folder, project_path_to_translation_id: Dict[Pa
                     else:
                         entry["Dialect"] = copy_string
 
-            if "Translation by" in copy_string:
-                entry["Translation by"] = copy_string
+            # TODO - improve logic to match cases like eng-lxx2012 where the search term
+            # is separated from the translators such that they end up different stripped strings
+            translation_search_term = "Translation by: "
+            if translation_search_term in copy_string:
+                entry["Translation by"] = copy_string[len(translation_search_term):]
             if "Public Domain" in copy_string:
                 entry["Copyright Years"] = ""
                 entry["Copyright Holder"] = "Public Domain"


### PR DESCRIPTION
This PR makes some changes to the `ebible.py` script mainly related to the logic that extracts licence details and generates the `licences.tsv` file. It's a collection of refactorings, a bugfix and a small enhancement.

### Refactorings

1. Remove some unused methods
2. Cleanup some old comments
3. Move edge case code for fixing licence details into the `get_licence_details` method so that the method is more self-contained. It is also a bit cleaner to address these issues at their source _before_ the data is read into a pandas dataframe.

### Bugfix

The "ID" column in the `licences.tsv` has been broken for a while. I infer from the code that it is supposed to be the original translation id from `translations.csv`, however prior to this PR it was the folder name of the paratext project.

In #57, there was some changes to fix a bug where the extract files ended up having a duplicated language code:

> The reason for the duplicated language codes is that the `bulk_extract_corpora` script creates the extract filename by prepending the language code onto the paratext project name. So if the project name already has a language code, then you get it twice.

> My fix is to pre-emptively remove the language code from paratext project name in anticipation of it being added later by bulk_extract_corpora.

This silently broke the "ID" field in the `licences.tsv` as it's based off the paratext project name. For example with a translation id like `abt-maprik`, the project name would now be just "maprik" meaning that the "ID" field has "maprik" instead of "abt-maprik".

I fixed this by keeping track of the mapping from projects to translation id's. During extraction of licence details, the code finds the name of the project and then maps it back to the translation id.

It's worth noting that the translation id from `translations.csv` is not the same as the final extract filename prefix, e.g. translation id `fra_fob` produces an extract file `fra-fob.txt`.

I'd want some input from David about what the original interpretation for the ID field was. I made it the translation id in this PR because that seemed closest to the original code before my recent PR's.

### Enhancement

The column "Translation by" in `licences.tsv` had values like: "Translation by: John Wycliffe". It is including the prefix `"Translation by: "`.

I modified the code to strip out the "Translation by: " so that the value would just be "John Wycliffe".

I also added a TODO because I found that the current search/extract logic doesn't work in all cases, for example the eng-lxx2012 which has html:

```
Translation by:<br />
Sir Lancelot Charles Lee Brenton<br />
Michael Paul Johnson<br />
```

The bug comes from a break `<br />` between the search term and the authors:

The strings to search are formed by taking the `stripped_strings`:

```py
copy_strings = list(soup.body.p.stripped_strings)
```

and there is an implicit assumption that the search term "Translation by: " will be in the same stripped string as the authors.

```py
if translation_search_term in copy_string:
    entry["Translation by"] = copy_string[len(translation_search_term):]
```

However in this case, the html has line breaks interspersed to put the multiple authors on separate lines which breaks the assumption. Potentially there are other translations with multiple authors also impacted by this bug.

It looked tricky to fix and beyond the scope of what I wanted to do in this PR, so I just left a TODO and will discuss with David as to how important it is to have this field correct. 